### PR TITLE
Add Laravel 13 and PHP 8.5 support, drop Laravel 9/10

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2, 8.1]
-        laravel: ['9.*', '10.*', '11.*', '12.*']
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
+        laravel: ['9.*', '10.*', '11.*', '12.*', '13.*']
         stability: [prefer-stable]
         include:
           - laravel: 9.*
@@ -28,15 +28,25 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
           - laravel: 12.*
             php: 8.1
           - laravel: 11.*
             php: 8.1
           - laravel: 10.*
             php: 8.4
+          - laravel: 10.*
+            php: 8.5
           - laravel: 9.*
             php: 8.4
+          - laravel: 9.*
+            php: 8.5
           - laravel: 9.*
             php: 8.3
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,14 +16,10 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.5, 8.4, 8.3, 8.2, 8.1]
-        laravel: ['9.*', '10.*', '11.*', '12.*', '13.*']
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: ['11.*', '12.*', '13.*']
         stability: [prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
@@ -32,23 +28,7 @@ jobs:
             testbench: 11.*
         exclude:
           - laravel: 13.*
-            php: 8.1
-          - laravel: 13.*
             php: 8.2
-          - laravel: 12.*
-            php: 8.1
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 10.*
-            php: 8.4
-          - laravel: 10.*
-            php: 8.5
-          - laravel: 9.*
-            php: 8.4
-          - laravel: 9.*
-            php: 8.5
-          - laravel: 9.*
-            php: 8.3
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
         "nunomaduro/collision": "^6.0|^8.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^1.21|^2.34|^3.7",
-        "pestphp/pest-plugin-laravel": "^1.1|^2.3|^3.1",
+        "pestphp/pest": "^1.21|^2.34|^3.7|^4.4.1",
+        "pestphp/pest-plugin-laravel": "^1.1|^2.3|^3.1|^4.1",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
         "phpstan/phpstan-phpunit": "^1.0|^2.0",
-        "phpunit/phpunit": "^9.5|^10.5|^11.5.3"
+        "phpunit/phpunit": "^9.5|^10.5|^11.5.3|^12.5.12"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
-        "symfony/mime": "^6.1|^7.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "symfony/mime": "^6.1|^7.0|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
         "nunomaduro/collision": "^6.0|^8.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "pestphp/pest": "^1.21|^2.34|^3.7",
         "pestphp/pest-plugin-laravel": "^1.1|^2.3|^3.1",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -17,22 +17,22 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
-        "symfony/mime": "^6.1|^7.0|^8.0"
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "symfony/mime": "^7.0|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
-        "nunomaduro/collision": "^6.0|^8.0",
-        "nunomaduro/larastan": "^2.0.1|^3.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^1.21|^2.34|^3.7|^4.4.1",
-        "pestphp/pest-plugin-laravel": "^1.1|^2.3|^3.1|^4.1",
+        "nunomaduro/collision": "^8.0",
+        "nunomaduro/larastan": "^3.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.7|^4.4.1",
+        "pestphp/pest-plugin-laravel": "^3.1|^4.1",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
-        "phpstan/phpstan-phpunit": "^1.0|^2.0",
-        "phpunit/phpunit": "^9.5|^10.5|^11.5.3|^12.5.12"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^11.5.3|^12.5.12"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,12 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     executionOrder="random"
@@ -16,24 +12,15 @@
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
 >
     <testsuites>
         <testsuite name="Creagia Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary
- Add support for Laravel 13 and PHP 8.5
- Drop support for Laravel 9, 10 and PHP 8.1
- Update dev dependencies (Pest 4, PHPUnit 12, Larastan 3)
- Migrate `phpunit.xml.dist` to modern PHPUnit 11+ schema
- Simplify CI matrix to PHP 8.2–8.5 × Laravel 11–13

## Test plan
- [ ] CI matrix passes for all PHP/Laravel combinations
- [ ] Laravel 13 builds successfully with PHP 8.3, 8.4, and 8.5